### PR TITLE
Update SqlServer17 default image tag

### DIFF
--- a/src/main/java/io/ebean/test/config/platform/SqlServerSetup.java
+++ b/src/main/java/io/ebean/test/config/platform/SqlServerSetup.java
@@ -26,7 +26,7 @@ class SqlServerSetup implements PlatformSetup {
       return new Properties();
     }
 
-    dbConfig.setDockerVersion("2017-CU4");
+    dbConfig.setDockerVersion("2017-cu19");
     return dbConfig.getDockerProperties();
   }
 


### PR DESCRIPTION
The CU4 tag is no longer available in the [list of tags](https://mcrflowprodcentralus.cdn.mscr.io/mcrprod/mssql/server?P1=1587847739&P2=1&P3=1&P4=7EPzA5uOuXc8k%2F84wO%2BmmCwVBsNrGVTNY5HCUUkF2G4%3D&se=2020-04-25T20%3A48%3A59Z&sig=xQg69saAHJQpw9JU9nBPcc7o6ZK%2FRQGI9oVrUTausgk%3D&sp=r&sr=b&sv=2015-02-21).
This change updates to the latest version for CU (although I don't know what CU means, but assume we can't just use "latest", since it's not CU).

It might also be nice to update the docs to show how to set the version. This is how I did it...
```
ebean:
  test:
    ...
    sqlserver:
      version: 2017-cu19
```